### PR TITLE
Fix growing zone for 1.1, allow cactus on sand

### DIFF
--- a/Source/MatchGrowingZone.cs
+++ b/Source/MatchGrowingZone.cs
@@ -20,13 +20,14 @@ namespace TD_Enhancement_Pack
 		public static FieldInfo startDragCellInfo = AccessTools.Field(typeof(DesignationDragger), "startDragCell");
 		public override AcceptanceReport CanDesignateCell(IntVec3 c)
 		{
-			if (!base.CanDesignateCell(c).Accepted)
-			{
-				return false;
-			}
+			//if (!base.CanDesignateCell(c).Accepted)
+			//{
+			//	return false;
+			//}
 
 			FertilityGrid grid = Map.fertilityGrid;
-			if (grid.FertilityAt(c) < ThingDefOf.Plant_Potato.plant.fertilityMin)
+			//if (grid.FertilityAt(c) < ThingDefOf.Plant_Potato.plant.fertilityMin)
+			if (grid.FertilityAt(c) < 0.05) //ThingDefOf.Plant_SaguaroCactus.plant.fertilityMin  cactus doesn't exist?
 			{
 				return false;
 			}


### PR DESCRIPTION
I know this isn't a proper edit, but it's the best I can do (the code actually kinda works, no matter how hacky it looks :P). I'm sure you know your codebase and Rimworld's much better than I do, and can fix this properly.

With 1.1 you can now plant SaguaroCactus, which has a min fertility rate of 0.05. Vanilla by default hasn't added the ability to place a grow zone on sand yet. I thought your Enhancements mod was a great place to fix this oversight.