### PR TITLE
Also show overlay for child class of CompGlower

### DIFF
--- a/Source/Overlays/LightingOverlay.cs
+++ b/Source/Overlays/LightingOverlay.cs
@@ -63,7 +63,7 @@ namespace TD_Enhancement_Pack
 		{
 			return des is Designator_Build desBuild &&
 				desBuild.PlacingDef is ThingDef def &&
-				def.HasComp(typeof(CompGlower));
+				def.comps.Any(c => typeof(CompGlower).IsAssignableFrom(c.compClass));
 		}
 	}
 


### PR DESCRIPTION
HasComp(CompGlower) only finds comps that are specifically CompGlower, but many mods have derived children classes, which will not be found.