### PR TITLE
Add Strip Zone Analagous to Slaughter Zone

### DIFF
--- a/Languages/English/Keyed/AutoEnglish.xml
+++ b/Languages/English/Keyed/AutoEnglish.xml
@@ -40,6 +40,7 @@
 	<TD.AreaEditing>Areas can be reordered, recolored, and copy/pasted in the area manager</TD.AreaEditing>
 	<TD.NeverHome>Make an area named 'Never Home' and the area will never be added to the Home Area</TD.NeverHome>
 	<TD.SlaughterZone>Make an area named 'Slaughter' and the animals will only be slaughtered in that area</TD.SlaughterZone>
+	<TD.StripZone>Make an area named 'Strip' and pawns will only be stripped in that area</TD.SlaughterZone>
 	<TD.RequiresRestart>These require a restart to take effect:</TD.RequiresRestart>
 	<TD.VariousCount>(various) selected items are given a count</TD.VariousCount>
 	<TD.RottedAwayClickable>Food 'rotted away' messages are clickable to see where it was</TD.RottedAwayClickable>

--- a/Languages/English/Keyed/AutoEnglish.xml
+++ b/Languages/English/Keyed/AutoEnglish.xml
@@ -40,7 +40,7 @@
 	<TD.AreaEditing>Areas can be reordered, recolored, and copy/pasted in the area manager</TD.AreaEditing>
 	<TD.NeverHome>Make an area named 'Never Home' and the area will never be added to the Home Area</TD.NeverHome>
 	<TD.SlaughterZone>Make an area named 'Slaughter' and the animals will only be slaughtered in that area</TD.SlaughterZone>
-	<TD.StripZone>Make an area named 'Strip' and pawns will only be stripped in that area</TD.SlaughterZone>
+	<TD.StripZone>Make an area named 'Strip' and pawns will only be stripped in that area</TD.StripZone>
 	<TD.RequiresRestart>These require a restart to take effect:</TD.RequiresRestart>
 	<TD.VariousCount>(various) selected items are given a count</TD.VariousCount>
 	<TD.RottedAwayClickable>Food 'rotted away' messages are clickable to see where it was</TD.RottedAwayClickable>

--- a/Source/HighwayToTheStripClub.cs
+++ b/Source/HighwayToTheStripClub.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse;
+using HarmonyLib;
+
+namespace TD_Enhancement_Pack
+{
+	[HarmonyPatch(typeof(WorkGiver_Strip), "HasJobOnThing")]
+	public static class HighwayToTheStripClub
+    {
+		//public override bool HasJobOnThing(Pawn pawn, Thing t, bool forced = false)
+		public static void Postfix(Pawn pawn, Thing t, bool forced, ref bool __result)
+		{
+			if (!__result || !Settings.Get().stripZone) return;
+
+			if (pawn.Map.areaManager.GetLabeled("Strip") is Area stripZone
+					&& !stripZone[t.Position])
+				__result = false;
+		}
+	}
+}

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -58,6 +58,7 @@ namespace TD_Enhancement_Pack
 		
 		public bool neverHome = true;
 		public bool slaughterZone = true;
+		public bool stripZone = true;
 
 		public bool autorebuildDefaultOn = true;
 		public bool autoRebuildTransportPod = false;
@@ -133,6 +134,7 @@ namespace TD_Enhancement_Pack
 			options.CheckboxLabeled("TD.SettingAreaForTypes".Translate(), ref areaForTypes, "TD.SettingAreaForTypesDesc".Translate());
 			options.CheckboxLabeled("TD.NeverHome".Translate(), ref neverHome);
 			options.CheckboxLabeled("TD.SlaughterZone".Translate(), ref slaughterZone);
+			options.CheckboxLabeled("TD.StripZone".Translate(), ref stripZone);
 			options.CheckboxLabeled("TD.SettingsCleanZone".Translate(), ref fieldEdgesRedo);
 			options.Label("TD.AreaEditing".Translate());
 			options.GapLine();
@@ -345,6 +347,7 @@ namespace TD_Enhancement_Pack
 
 			Scribe_Values.Look(ref neverHome, "neverHome", true);
 			Scribe_Values.Look(ref slaughterZone, "slaughterZone", true);
+			Scribe_Values.Look(ref stripZone, "stripZone", true);
 
 			Scribe_Values.Look(ref autorebuildDefaultOn, "autorebuildDefaultOn", true);
 			Scribe_Values.Look(ref autoRebuildTransportPod, "autoRebuildTransportPod", false);


### PR DESCRIPTION
### Add Strip Zone Analagous to Slaughter Zone

We add a setting for "Strip" zone exactly analagous to "Slaughter" zone.

Game-logic reasoning for this is straightforward- dead enemies need to be burned. If you burn their apparel with them, you don't care about this.

But optimally, they should be stripped, because even if you don't want to directly _wear_ that Tainted Marine Armor, you can still smelt it down for materials. If you leave it on the body and cremate it, it is wasted.

But if you strip the body where it originally died, there is extra hauling -- you have to haul each time the body, then each thing you stripped.

Ideally, you haul the body once, with the equipment still on, and then, when it is in a better spot, _then_ you strip it.

You need to strip it before you cremate it though.

The ordering of the WorkGiver priorities starts to get really wonky, and you have to start micromanaging your Strip designator.

This lets you globally mark every corpse for Strip, just once, when the fight is over, and each corpse won't be stripped until _after_ it gets hauled to the appropriate location. If your crematorium area is the "Strip Corpse" area implemented here, then as long as "Strip corpse" is higher priority than "Cremate", then the right thing happens magically: Pawns haul corpses to the crematorium with gear still equipped, then strip it at the crematorium, then cremate the naked body and process the gear.