### PR TITLE
Update to RimWorld 1.3

### DIFF
--- a/About/About-Debug.xml
+++ b/About/About-Debug.xml
@@ -6,6 +6,7 @@
 		<li>1.0</li>
 		<li>1.1</li>
 		<li>1.2</li>
+		<li>1.3</li>
 	</supportedVersions>
 	<packageId>DEBUuugggg.TDPack</packageId>
 	<description>Various things that just should be in the game. 

--- a/About/About-Release.xml
+++ b/About/About-Release.xml
@@ -6,6 +6,7 @@
 		<li>1.0</li>
 		<li>1.1</li>
 		<li>1.2</li>
+		<li>1.3</li>
 	</supportedVersions>
 	<packageId>Uuugggg.TDPack</packageId>
 	<description>Various things that just should be in the game.

--- a/Source/AreaEditable.cs
+++ b/Source/AreaEditable.cs
@@ -119,8 +119,9 @@ namespace TD_Enhancement_Pack
 		{
 			if (Settings.Get().areasUnlimited)
 			{
-				listing.EndScrollView(ref viewRect);
-				scrollViewHeight = viewRect.height;
+				scrollViewHeight = listing.CurHeight;
+				Widgets.EndScrollView();
+				listing.End();
 			}
 			else
 				listing.End();
@@ -269,7 +270,7 @@ namespace TD_Enhancement_Pack
 					comp.Swap(area, other);
 				}
 			}
-			else widgetRow.GapButtonIcon();
+			else widgetRow.Gap(WidgetRow.IconSize);
 
 			//re-order down
 			if (index < areas.Count - 1)
@@ -280,7 +281,7 @@ namespace TD_Enhancement_Pack
 					comp.Swap(area, other);
 				}
 			}
-			else widgetRow.GapButtonIcon();
+			else widgetRow.Gap(WidgetRow.IconSize);
 		}
 
 		public static void DoButtonIcon(WidgetRow widgetRow, Texture2D tex, string tooltip, Area area)
@@ -312,7 +313,7 @@ namespace TD_Enhancement_Pack
 				{
 					List<FloatMenuOption> otherAreas = new List<FloatMenuOption>(area.Map.areaManager.AllAreas
 						.FindAll(a => !(a is Area_Allowed))
-						.ConvertAll(a => new FloatMenuOption(a.Label, () => PasteArea(a, area), mouseoverGuiAction: () => a.MarkForDraw())));
+						.ConvertAll(a => new FloatMenuOption(a.Label, () => PasteArea(a, area), mouseoverGuiAction: (_) => a.MarkForDraw())));
 					Find.WindowStack.Add(new FloatMenu(otherAreas, "TD.PasteFrom".Translate()));
 				}
 				else

--- a/Source/ColorVariation.cs
+++ b/Source/ColorVariation.cs
@@ -98,7 +98,7 @@ namespace TD_Enhancement_Pack
 					}
 
 					if (color != thing.DrawColor)
-						comp.Color = color;
+						comp.SetColor(color);
 					Log.Message($"{thing} color now {thing.DrawColor}/{comp.Active}:{comp.Color}");
 				}
 			}

--- a/Source/ColorVariation.cs
+++ b/Source/ColorVariation.cs
@@ -185,7 +185,7 @@ namespace TD_Enhancement_Pack
 			//Variation
 		}
 
-		public static MethodInfo ApparelChangedInfo = AccessTools.Method(typeof(Pawn_ApparelTracker), "ApparelChanged");
+		public static MethodInfo ApparelChangedInfo = AccessTools.Method(typeof(Pawn_ApparelTracker), "Notify_ApparelChanged");
 		public static void ApparelChanged(this Pawn_ApparelTracker appTracker) =>
 			ApparelChangedInfo.Invoke(appTracker, new object[] { });
 		public static void Go()

--- a/Source/FleeGrenadeDrafted.cs
+++ b/Source/FleeGrenadeDrafted.cs
@@ -6,6 +6,9 @@ using Verse;
 using Verse.AI;
 using RimWorld;
 using HarmonyLib;
+using System.Reflection;
+using System.Reflection.Emit;
+
 
 namespace TD_Enhancement_Pack
 {
@@ -32,14 +35,57 @@ namespace TD_Enhancement_Pack
 		}
 
 		//public static void NotifyNearbyPawnsOfDangerousExplosive(Thing exploder, DamageDef damage, Faction onlyFaction = null)
-		public static void NOFACTIONNotifyNearbyPawnsOfDangerousExplosive(Thing exploder, DamageDef damage, Faction onlyFaction = null)
+		public static void NOFACTIONNotifyNearbyPawnsOfDangerousExplosive(Thing exploder, DamageDef damage, Faction onlyFaction = null, Thing launcher = null)
 		{
 			Faction actualFaction = onlyFaction;
 			if (Settings.Get().dodgeGrenadeEnemy && onlyFaction != Faction.OfPlayer)
 				actualFaction = null;
 			if (Settings.Get().dodgeGrenadeNPC && onlyFaction == Faction.OfPlayer)
 				actualFaction = null;
-			GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(exploder, damage, actualFaction);
+			GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(exploder, damage, actualFaction, launcher);
 		}
+	}
+
+
+	[HarmonyPatch(typeof(Pawn_MindState), "Notify_DangerousExploderAboutToExplode")]
+	public static class Pawn_MindState_Notify_DangerousExploderAboutToExplode_Patch
+	{
+		/// <summary>
+		/// Harmony Transpiler to change that drafted pawns also move away from explosions
+		/// </summary>
+		/// <explanation>
+		/// The transpiler adds an additional check (CheckDodgeGrenade), which is called from 
+		/// Assembly-CSharp.dll --> Verse.AI.Pawn_MindState.Notify_DangerousExploderAboutToExplode 
+		/// This check is nessecery to the additional condition "&& !this.pawn.Drafted" in Notify_DangerousExploderAbouttoExplode in RimWorld_1.3
+		/// 
+		/// The Transpiler search for the Command "Boolean get_Drafted()" in the IL-Code in Notity_DangerousExploderAboutToExplode
+		/// and adds after this command the call to the CheckDodgeGrenade instead for only checking the draftet status of the pawn.
+		/// </explanation>
+		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+		{
+			bool found = false;
+			foreach (var instruction in instructions)
+			{
+				yield return instruction;
+				if ((instruction.operand ?? string.Empty).ToString() == "Boolean get_Drafted()")
+				{
+					yield return new CodeInstruction(OpCodes.Call, m_CheckDodgeGrenade);
+					found = true;
+				}
+			}
+			if (found is false)
+				Verse.Log.Error("Cannot find 'Boolean get_Drafted()' in Pawn_MindState_Notify_DangerousExploderAboutToExplode");
+		}
+		/// <summary>
+		/// If the setting dodgeGrenade is turned on (TRUE) then the function always return FALSE.
+		/// Else the function returns the original drafted value
+		/// </summary>
+		/// <param name="drafted"></param>
+		/// <returns>FALSE for notify pawn about dangerous explosion</returns>
+		public static bool CheckDodgeGrenade(bool drafted)
+		{
+			return !Settings.Get().dodgeGrenade && drafted;
+		}
+		static MethodInfo m_CheckDodgeGrenade = SymbolExtensions.GetMethodInfo(() => CheckDodgeGrenade(true));
 	}
 }

--- a/Source/NotSoHostile.cs
+++ b/Source/NotSoHostile.cs
@@ -32,11 +32,11 @@ namespace TD_Enhancement_Pack
 		}
 
 		//public static IAttackTarget BestAttackTarget(IAttackTargetSearcher searcher, TargetScanFlags flags, Predicate<Thing> validator = null, float minDist = 0, float maxDist = 9999, IntVec3 locus = default(IntVec3), float maxTravelRadiusFromLocus = float.MaxValue, bool canBash = false, bool canTakeTargetsCloserThanEffectiveMinRange = true);
-		public static IAttackTarget BetterAttackTarget(IAttackTargetSearcher searcher, TargetScanFlags flags, Predicate<Thing> validator = null, float minDist = 0f, float maxDist = 9999f, IntVec3 locus = default(IntVec3), float maxTravelRadiusFromLocus = 3.40282347E+38f, bool canBash = false, bool canTakeTargetsCloserThanEffectiveMinRange = true)
+		public static IAttackTarget BetterAttackTarget(IAttackTargetSearcher searcher, TargetScanFlags flags, Predicate<Thing> validator = null, float minDist = 0f, float maxDist = 9999f, IntVec3 locus = default(IntVec3), float maxTravelRadiusFromLocus = 3.40282347E+38f, bool canBash = false, bool canTakeTargetsCloserThanEffectiveMinRange = true, bool canBashFance = false)
 		{
 			return AttackTargetFinder.BestAttackTarget(searcher, flags,
 				Settings.Get().ignoreSleepingEnemies ? ThingIsNotSleeping : validator,  //validator is null for TryGetAttackNearbyEnemyJob, otherwise this is totally broken
-				minDist, maxDist, locus, maxTravelRadiusFromLocus, canBash, canTakeTargetsCloserThanEffectiveMinRange);
+				minDist, maxDist, locus, maxTravelRadiusFromLocus, canBash, canTakeTargetsCloserThanEffectiveMinRange, canBashFance);
 		}
 
 		public static bool ThingIsNotSleeping(Thing t)

--- a/Source/RebuildTransportPod.cs
+++ b/Source/RebuildTransportPod.cs
@@ -19,7 +19,7 @@ namespace TD_Enhancement_Pack
 
 			if (Find.PlaySettings.autoRebuild && thing.Faction == Faction.OfPlayer && buildingDef.blueprintDef != null && buildingDef.IsResearchFinished && map.areaManager.Home[thing.Position] && GenConstruct.CanPlaceBlueprintAt(buildingDef, thing.Position, thing.Rotation, map, false, null).Accepted)
 			{
-				GenConstruct.PlaceBlueprintForBuild(buildingDef, thing.Position, map, thing.Rotation, Faction.OfPlayer, thing.Stuff);
+				GenConstruct.PlaceBlueprintForBuild_NewTemp(buildingDef, thing.Position, map, thing.Rotation, Faction.OfPlayer, thing.Stuff);
 			}
 		}
 

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -291,8 +291,9 @@ namespace TD_Enhancement_Pack
 			options.Label("TD.DropdownBuildingsOrder".Translate(), tooltip: "TD.DropdownBuildingsOrderDesc".Translate());
 			options.Label("TD.FeatureConfirmRestoreSettings".Translate());
 
-			options.EndScrollView(ref viewRect);
-			scrollViewHeight = viewRect.height;
+			scrollViewHeight = options.CurHeight;
+			Widgets.EndScrollView();
+			options.End();
 		}
 
 		public override void ExposeData()


### PR DESCRIPTION
I made some changes, so this mod is with RimWorld 1.3 compatible.
Mostly only some names of methods have changed or new parameter where added.

The removal of the EndScrollView method was a bit complicated and i am not sure that my workaround is "good" Code, but it works. 
For the FleeGrenadeDrafted Code i have to add a new Transpiler, because RimWorld added an additional check in the AssemblyCSharp.dll for drafted pawns. 

In my Testing i have not found any errors, but i also not use all settings in my playthrough.

Here is the finished Version. I changed the mod folders, so its with 1.3 confirm and downward compatible with the old 1.2 Assembly.
[TD_EnhancementPack-1.3.zip](https://github.com/alextd/RimWorld-EnhancementPack/files/6935322/TD_EnhancementPack-1.3.zip)

I hope you can work with my changes and release a 1.3 Version. 
Especially on Steam many people waiting for the Update ;)
